### PR TITLE
Update linux-ci to add macos-26 and action updates for Node 24

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -45,9 +45,6 @@ jobs:
             build_static: false
             flags: CC=gcc-13 CXX=g++-13 ADD_CXXFLAGS=-Wl,-ld_classic
             download_requirements: brew install metis bash
-      matrix:
-        include:
-
     steps:
       - name: Checkout source
         uses: actions/checkout@v6

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -19,15 +19,35 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-22.04, ubuntu-24.04]
+        build_static: [true, false]
+        flags: [ADD_CXXFLAGS=-fvisibility=hidden]
+        download_requirements: [sudo apt install -y -qq gfortran liblapack-dev libmetis-dev libnauty-dev]
         include:
+          - os: macos-26-intel
+            build_static: false
+            flags: CC=clang CXX=clang++
+            download_requirements: brew install metis bash
+          - os: macos-15-intel
+            build_static: false
+            flags: CC=gcc-15 CXX=g++-15 ADD_CXXFLAGS=-Wl,-ld_classic
+            download_requirements: brew install metis bash
           - os: macos-26
             build_static: false
             flags: CC=gcc-15 CXX=g++-15 ADD_CXXFLAGS=-Wl,-ld_classic
-            download_requirements: brew install metis bash lapack nauty 
-          - os: macos-26-intel
+            download_requirements: brew install metis bash
+          - os: macos-15
             build_static: false
-            flags: CC=gcc-15 CXX=g++-15 ADD_CXXFLAGS=-Wl,-ld_classic
-            download_requirements: brew install metis bash lapack nauty
+            flags: CC=clang CXX=clang++
+            download_requirements: brew install metis bash
+          - os: macos-14
+            arch: arm64
+            build_static: false
+            flags: CC=gcc-13 CXX=g++-13 ADD_CXXFLAGS=-Wl,-ld_classic
+            download_requirements: brew install metis bash
+      matrix:
+        include:
+
     steps:
       - name: Checkout source
         uses: actions/checkout@v6

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -77,7 +77,7 @@ jobs:
           platform_str=`python3 tools/hsf_get_platform.py -b $buildtype`
           echo "platform_string=${platform_str}" >> $GITHUB_ENV
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ github.event.repository.name }}-${{ env.platform_string }}.tar.gz
           path: release.tar.gz

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -22,7 +22,11 @@ jobs:
         include:
           - os: macos-26
             build_static: false
-            flags: CC=gcc-15 CXX=g++-15 OSX=26 ADD_CXXFLAGS=-Wl,-ld_classic
+            flags: CC=gcc-15 CXX=g++-15 ADD_CXXFLAGS=-Wl,-ld_classic
+            download_requirements: brew install metis bash
+          - os: macos-26-intel
+            build_static: false
+            flags: CC=gcc-15 CXX=g++-15 ADD_CXXFLAGS=-Wl,-ld_classic
             download_requirements: brew install metis bash
     steps:
       - name: Checkout source

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -23,7 +23,7 @@ jobs:
           - os: macos-26
             build_static: false
             flags: CC=gcc-15 CXX=g++-15 OSX=26 ADD_CXXFLAGS=-Wl,-ld_classic
-            download_requirements: metis
+            download_requirements: brew install metis
     steps:
       - name: Checkout source
         uses: actions/checkout@v4

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -19,10 +19,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: []
-        build_static: [true, false]
-        flags: [ADD_CXXFLAGS=-fvisibility=hidden]
-        download_requirements: [sudo apt install -y -qq gfortran liblapack-dev libmetis-dev libnauty-dev]
         include:
           - os: macos-26
             build_static: false

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -18,16 +18,21 @@ jobs:
     name: Run tests
     runs-on: ${{ matrix.os }}
     strategy:
-      matrix:
-        include:
-          - os: macos-26
-            build_static: false
-            flags: CC=gcc-15 CXX=g++-15 ADD_CXXFLAGS=-Wl,-ld_classic
-            download_requirements: brew install metis bash
-          - os: macos-26-intel
-            build_static: false
-            flags: CC=gcc-15 CXX=g++-15 ADD_CXXFLAGS=-Wl,-ld_classic
-            download_requirements: brew install metis bash
+      - matrix:
+          os: [ubuntu-22.04, ubuntu-24.04]
+          build_static: [true, false]
+          flags: [ADD_CXXFLAGS=-fvisibility=hidden]
+          download_requirements: [sudo apt install -y -qq gfortran liblapack-dev libmetis-dev libnauty-dev]
+      - matrix:
+          include:
+            - os: macos-26
+              build_static: false
+              flags: CC=gcc-15 CXX=g++-15 ADD_CXXFLAGS=-Wl,-ld_classic
+              download_requirements: brew install metis bash
+            - os: macos-26-intel
+              build_static: false
+              flags: CC=gcc-15 CXX=g++-15 ADD_CXXFLAGS=-Wl,-ld_classic
+              download_requirements: brew install metis bash
     steps:
       - name: Checkout source
         uses: actions/checkout@v4

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -30,13 +30,13 @@ jobs:
             download_requirements: brew install metis bash lapack nauty
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: ${{ github.event.repository.name }}
       - name: Install required packages from package manager
         run: ${{ matrix.download_requirements }}
       - name: Checkout coinbrew
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: coin-or/coinbrew
           path: coinbrew
@@ -63,7 +63,7 @@ jobs:
           cp ${{ github.event.repository.name }}/LICENSE dist/
           tar -czvf release.tar.gz -C dist .
       - name: Checkout package name generation script
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: coin-or-tools/platform-analysis-tools
           path: tools

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -18,21 +18,16 @@ jobs:
     name: Run tests
     runs-on: ${{ matrix.os }}
     strategy:
-      - matrix:
-          os: [ubuntu-22.04, ubuntu-24.04]
-          build_static: [true, false]
-          flags: [ADD_CXXFLAGS=-fvisibility=hidden]
-          download_requirements: [sudo apt install -y -qq gfortran liblapack-dev libmetis-dev libnauty-dev]
-      - matrix:
-          include:
-            - os: macos-26
-              build_static: false
-              flags: CC=gcc-15 CXX=g++-15 ADD_CXXFLAGS=-Wl,-ld_classic
-              download_requirements: brew install metis bash
-            - os: macos-26-intel
-              build_static: false
-              flags: CC=gcc-15 CXX=g++-15 ADD_CXXFLAGS=-Wl,-ld_classic
-              download_requirements: brew install metis bash
+      matrix:
+        include:
+          - os: macos-26
+            build_static: false
+            flags: CC=gcc-15 CXX=g++-15 ADD_CXXFLAGS=-Wl,-ld_classic
+            download_requirements: brew install metis bash lapack nauty 
+          - os: macos-26-intel
+            build_static: false
+            flags: CC=gcc-15 CXX=g++-15 ADD_CXXFLAGS=-Wl,-ld_classic
+            download_requirements: brew install metis bash lapack nauty
     steps:
       - name: Checkout source
         uses: actions/checkout@v4

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -23,7 +23,7 @@ jobs:
           - os: macos-26
             build_static: false
             flags: CC=gcc-15 CXX=g++-15 OSX=26 ADD_CXXFLAGS=-Wl,-ld_classic
-            download_requirements: brew install metis
+            download_requirements: brew install metis bash
     steps:
       - name: Checkout source
         uses: actions/checkout@v4

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -19,24 +19,15 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04]
+        os: []
         build_static: [true, false]
         flags: [ADD_CXXFLAGS=-fvisibility=hidden]
         download_requirements: [sudo apt install -y -qq gfortran liblapack-dev libmetis-dev libnauty-dev]
         include:
-          - os: macos-15-intel
+          - os: macos-26
             build_static: false
-            flags: CC=clang CXX=clang++ OSX=15
-            download_requirements: brew install metis bash
-          - os: macos-15-intel
-            build_static: false
-            flags: CC=gcc-15 CXX=g++-15 OSX=15 ADD_CXXFLAGS=-Wl,-ld_classic
-            download_requirements: brew install metis bash
-          - os: macos-14
-            arch: arm64
-            build_static: false
-            flags: CC=gcc-13 CXX=g++-13 OSX=14 ADD_CXXFLAGS=-Wl,-ld_classic
-            download_requirements: brew install metis bash
+            flags: CC=gcc-15 CXX=g++-15 OSX=26 ADD_CXXFLAGS=-Wl,-ld_classic
+            download_requirements: metis
     steps:
       - name: Checkout source
         uses: actions/checkout@v4


### PR DESCRIPTION
- Update linux-ci to add the new macos-26 and macos-26-intel runners.
-- Simplify the combinations of macos and compilers (gcc / clang)
-- Remove "OSX=xx" flags. It seems not used.
-- Remove "arch: arm64" for macos-14. It seems not used.

- Update several actions to recent versions that use Node 24 rather than the old Node 20. See recent Action warnings.